### PR TITLE
More broken token/unicode/txn oddness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <jena.version>2.7.1-incubating-SNAPSHOT</jena.version>
     <arq.version>2.9.1-incubating-SNAPSHOT</arq.version>
     <tdb.version>0.9.1-incubating-SNAPSHOT</tdb.version>
-    <larq.version>1.0-incubating-SNAPSHOT</larq.version>
+    <larq.version>1.0.0-incubating-SNAPSHOT</larq.version>
     <iri.version>0.9.1-incubating-SNAPSHOT</iri.version>
     <java-rdfa.version>0.4.2-RC2</java-rdfa.version>
     <jena-jung.version>0.1.1</jena-jung.version>

--- a/src/main/java/dev/Run3.java
+++ b/src/main/java/dev/Run3.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev;
+
+import java.util.Iterator;
+
+import org.openjena.riot.Lang;
+import org.openjena.riot.RiotLoader;
+import org.openjena.riot.RiotWriter;
+
+import com.hp.hpl.jena.query.Dataset;
+import com.hp.hpl.jena.query.ReadWrite;
+import com.hp.hpl.jena.sparql.core.DatasetGraph;
+import com.hp.hpl.jena.sparql.core.Quad;
+import com.hp.hpl.jena.tdb.TDBFactory;
+import com.hp.hpl.jena.tdb.base.file.Location;
+
+public class Run3 {
+
+    public static void main(String[] args) {
+        Location location = new Location ( "target/tdb" );
+        Dataset dataset = TDBFactory.createDataset ( location );
+        dataset.begin ( ReadWrite.WRITE );
+        try {
+            DatasetGraph dsg = dataset.asDatasetGraph();
+            DatasetGraph dsg2 = RiotLoader.load("src/main/resources/data/single-bad-triple.nt", Lang.NTRIPLES);
+            Iterator<Quad> quads = dsg2.find();
+            while ( quads.hasNext() ) {
+                Quad quad = quads.next();
+                dsg.add(quad);
+            }
+            dataset.commit();
+        } catch ( Exception e ) {
+            e.printStackTrace(System.err);
+            dataset.abort();
+        } finally {
+            dataset.end();
+        }
+        RiotWriter.writeNQuads(System.out, dataset.asDatasetGraph());
+    }
+
+}

--- a/src/main/resources/data/single-bad-triple.nt
+++ b/src/main/resources/data/single-bad-triple.nt
@@ -1,0 +1,1 @@
+<ex:s> <ex:p> "berthnasol i\u0092r t\uDAE0ar yr wyneb lo ag yw i\u0092r c\U000F07EDeibion" .


### PR DESCRIPTION
Another case where illegal/invalid NTriples (I think) causes Txn failure - leaving the db unrecoverable using JournalControl. So far, I've only managed to reproduce this by reading the triple from a file (i.e. not from a Java String)
